### PR TITLE
Update GitHub demos with active projects and latest NuGet packages for Word Library

### DIFF
--- a/Create-Envelopes-for-mailing/Console-App-.NET-Core/Create-Envelopes-for-mailing/Create-Envelopes-for-mailing.csproj
+++ b/Create-Envelopes-for-mailing/Console-App-.NET-Core/Create-Envelopes-for-mailing/Create-Envelopes-for-mailing.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Create_Envelopes_for_mailing</RootNamespace>
   </PropertyGroup>
 

--- a/Create-and-send-email-messages/Console-App-.NET-Core/Create-and-send-email-messages/Create-and-send-email-messages.csproj
+++ b/Create-and-send-email-messages/Console-App-.NET-Core/Create-and-send-email-messages/Create-and-send-email-messages.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Create-personalized-letter/Console-App-.NET-Core/Create-personalized-letter/Create-personalized-letter.csproj
+++ b/Create-personalized-letter/Console-App-.NET-Core/Create-personalized-letter/Create-personalized-letter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Fit-photo-within-textbox/Console-App-.NET-Framework/Fit-photo-within-textbox/App.config
+++ b/Fit-photo-within-textbox/Console-App-.NET-Framework/Fit-photo-within-textbox/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
     </startup>
 </configuration>

--- a/Fit-photo-within-textbox/Console-App-.NET-Framework/Fit-photo-within-textbox/Fit-photo-within-textbox.csproj
+++ b/Fit-photo-within-textbox/Console-App-.NET-Framework/Fit-photo-within-textbox/Fit-photo-within-textbox.csproj
@@ -8,10 +8,11 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Fit_photo_within_textbox</RootNamespace>
     <AssemblyName>Fit-photo-within-textbox</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -33,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=18.2460.0.44, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.18.2.0.44\lib\net46\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.26.1.42\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=18.2460.0.44, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.18.2.0.44\lib\net46\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.26.1.42\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=18.2460.0.44, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.18.2.0.44\lib\net46\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.26.1.42\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=18.2460.0.44, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.18.2.0.44\lib\net46\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.26.1.42\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Fit-photo-within-textbox/Console-App-.NET-Framework/Fit-photo-within-textbox/packages.config
+++ b/Fit-photo-within-textbox/Console-App-.NET-Framework/Fit-photo-within-textbox/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="18.2.0.44" targetFramework="net46" />
-  <package id="Syncfusion.DocIO.WinForms" version="18.2.0.44" targetFramework="net46" />
-  <package id="Syncfusion.Licensing" version="18.2.0.44" targetFramework="net46" />
-  <package id="Syncfusion.OfficeChart.Base" version="18.2.0.44" targetFramework="net46" />
+  <package id="Syncfusion.Compression.Base" version="26.1.42" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="26.1.42" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="26.1.42" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="26.1.42" targetFramework="net462" />
 </packages>

--- a/Generate-Barcode-labels/Console-APP-.NET-Core/Generate-Barcode-labels/Generate-Barcode-labels.csproj
+++ b/Generate-Barcode-labels/Console-APP-.NET-Core/Generate-Barcode-labels/Generate-Barcode-labels.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Generate_Barcode_labels</RootNamespace>
   </PropertyGroup>
 

--- a/Generate-Barcode-labels/Console-APP-.NET-Core/Generate-Barcode-labels/Program.cs
+++ b/Generate-Barcode-labels/Console-APP-.NET-Core/Generate-Barcode-labels/Program.cs
@@ -4,8 +4,6 @@ using Syncfusion.Pdf.Barcode;
 using Syncfusion.Pdf.Graphics;
 using System;
 using System.Data;
-using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
 
 namespace Generate_Barcode_labels
@@ -58,11 +56,8 @@ namespace Generate_Barcode_labels
             barcode.BarHeight = 45;
             barcode.Text = barcodeText;
             //Convert the barcode to image 
-            Image barcodeImage = barcode.ToImage(new System.Drawing.SizeF(145, 45));
-            //Converts image to stream
-            MemoryStream stream = new MemoryStream();
-            barcodeImage.Save(stream, ImageFormat.Png);
-            return stream;
+            Stream imageStream = barcode.ToImage(new Syncfusion.Drawing.SizeF(145, 45));
+            return imageStream;
         }
 
         /// <summary>

--- a/Generate-Barcode-labels/Console-App-.NET-Framework/Generate-Barcode-labels/App.config
+++ b/Generate-Barcode-labels/Console-App-.NET-Framework/Generate-Barcode-labels/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
     </startup>
 </configuration>

--- a/Generate-Barcode-labels/Console-App-.NET-Framework/Generate-Barcode-labels/Generate-Barcode-labels.csproj
+++ b/Generate-Barcode-labels/Console-App-.NET-Framework/Generate-Barcode-labels/Generate-Barcode-labels.csproj
@@ -8,9 +8,10 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Generate-Barcode-labels</RootNamespace>
     <AssemblyName>Generate-Barcode-labels</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -32,20 +33,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=17.2460.0.34, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.17.2.0.34\lib\net46\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.26.1.42\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=17.2460.0.34, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.17.2.0.34\lib\net46\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.26.1.42\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=17.2460.0.34, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.17.2.0.34\lib\net46\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.26.1.42\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=17.2460.0.34, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.17.2.0.34\lib\net46\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.26.1.42\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Pdf.Base, Version=17.2460.0.34, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Pdf.WinForms.17.2.0.34\lib\net46\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Pdf.WinForms.26.1.42\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Generate-Barcode-labels/Console-App-.NET-Framework/Generate-Barcode-labels/packages.config
+++ b/Generate-Barcode-labels/Console-App-.NET-Framework/Generate-Barcode-labels/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="17.2.0.34" targetFramework="net46" />
-  <package id="Syncfusion.DocIO.WinForms" version="17.2.0.34" targetFramework="net46" />
-  <package id="Syncfusion.Licensing" version="17.2.0.34" targetFramework="net46" />
-  <package id="Syncfusion.OfficeChart.Base" version="17.2.0.34" targetFramework="net46" />
-  <package id="Syncfusion.Pdf.WinForms" version="17.2.0.34" targetFramework="net46" />
+  <package id="Syncfusion.Compression.Base" version="26.1.42" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="26.1.42" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="26.1.42" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="26.1.42" targetFramework="net462" />
+  <package id="Syncfusion.Pdf.WinForms" version="26.1.42" targetFramework="net462" />
 </packages>

--- a/Generate-multiple-Word-documents/Console-App-.NET-Framework/Generate-multiple-Word-documents/App.config
+++ b/Generate-multiple-Word-documents/Console-App-.NET-Framework/Generate-multiple-Word-documents/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
     </startup>
 </configuration>

--- a/Generate-multiple-Word-documents/Console-App-.NET-Framework/Generate-multiple-Word-documents/Generate-multiple-Word-documents.csproj
+++ b/Generate-multiple-Word-documents/Console-App-.NET-Framework/Generate-multiple-Word-documents/Generate-multiple-Word-documents.csproj
@@ -8,9 +8,10 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Generate_multiple_Word_documents</RootNamespace>
     <AssemblyName>Generate-multiple-Word-documents</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -32,17 +33,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=17.1460.0.48, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.17.1.0.48\lib\net46\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.26.1.42\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=17.1460.0.48, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.17.1.0.48\lib\net46\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.26.1.42\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=17.1460.0.48, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.17.1.0.48\lib\net46\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.26.1.42\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=17.1460.0.48, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.17.1.0.48\lib\net46\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.26.1.42\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Generate-multiple-Word-documents/Console-App-.NET-Framework/Generate-multiple-Word-documents/packages.config
+++ b/Generate-multiple-Word-documents/Console-App-.NET-Framework/Generate-multiple-Word-documents/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="17.1.0.48" targetFramework="net46" />
-  <package id="Syncfusion.DocIO.WinForms" version="17.1.0.48" targetFramework="net46" />
-  <package id="Syncfusion.Licensing" version="17.1.0.48" targetFramework="net46" />
-  <package id="Syncfusion.OfficeChart.Base" version="17.1.0.48" targetFramework="net46" />
+  <package id="Syncfusion.Compression.Base" version="26.1.42" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="26.1.42" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="26.1.42" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="26.1.42" targetFramework="net462" />
 </packages>

--- a/Generate-order-details-of-customer/Console-App-.NET-Core/Generate-order-details-of-customer/Generate-order-details-of-customer.csproj
+++ b/Generate-order-details-of-customer/Console-App-.NET-Core/Generate-order-details-of-customer/Generate-order-details-of-customer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Group-Mail-merge-using-Excel/Console-App-.NET-Core/Group-Mail-merge-using-Excel/Group-Mail-merge-using-Excel.csproj
+++ b/Group-Mail-merge-using-Excel/Console-App-.NET-Core/Group-Mail-merge-using-Excel/Group-Mail-merge-using-Excel.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Product-catalog/Console-App-.NET-Core/Product-catalog/Product-catalog.csproj
+++ b/Product-catalog/Console-App-.NET-Core/Product-catalog/Product-catalog.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Product_catalog</RootNamespace>
   </PropertyGroup>
 

--- a/Replace-Merge-field-with-HTML/Console-App-.NET-Framework/Replace-Merge-field-with-HTML/App.config
+++ b/Replace-Merge-field-with-HTML/Console-App-.NET-Framework/Replace-Merge-field-with-HTML/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
     </startup>
 </configuration>

--- a/Replace-Merge-field-with-HTML/Console-App-.NET-Framework/Replace-Merge-field-with-HTML/Replace-Merge-field-with-HTML.csproj
+++ b/Replace-Merge-field-with-HTML/Console-App-.NET-Framework/Replace-Merge-field-with-HTML/Replace-Merge-field-with-HTML.csproj
@@ -8,10 +8,11 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Replace_Merge_field_with_HTML</RootNamespace>
     <AssemblyName>Replace-Merge-field-with-HTML</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -33,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=18.2460.0.44, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.18.2.0.44\lib\net46\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.26.1.42\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=18.2460.0.44, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.18.2.0.44\lib\net46\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.26.1.42\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=18.2460.0.44, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.18.2.0.44\lib\net46\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.26.1.42\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=18.2460.0.44, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.18.2.0.44\lib\net46\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=26.1462.42.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.26.1.42\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Replace-Merge-field-with-HTML/Console-App-.NET-Framework/Replace-Merge-field-with-HTML/packages.config
+++ b/Replace-Merge-field-with-HTML/Console-App-.NET-Framework/Replace-Merge-field-with-HTML/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="18.2.0.44" targetFramework="net46" />
-  <package id="Syncfusion.DocIO.WinForms" version="18.2.0.44" targetFramework="net46" />
-  <package id="Syncfusion.Licensing" version="18.2.0.44" targetFramework="net46" />
-  <package id="Syncfusion.OfficeChart.Base" version="18.2.0.44" targetFramework="net46" />
+  <package id="Syncfusion.Compression.Base" version="26.1.42" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="26.1.42" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="26.1.42" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="26.1.42" targetFramework="net462" />
 </packages>

--- a/Start-each-record-on-new-page/Console-App-.NET-Core/Start-each-record-on-new-page/Start-each-record-on-new-page.csproj
+++ b/Start-each-record-on-new-page/Console-App-.NET-Core/Start-each-record-on-new-page/Start-each-record-on-new-page.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Start_each_record_on_new_page</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
1. Change Syncfusion NuGet versions with * instead of static version in all cross platform samples.
2. Cross platform samples should be .NET 8.0 target. (ASP.NET Core web app, Core console). Change the samples.
3. .NET Framework samples must be .NET 4.6.2 target.
4. Delete projects which reached end of .NET life cycle.